### PR TITLE
Switch to using c++_shared for C++ standard library (#202)

### DIFF
--- a/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
+++ b/Build/libHttpClient.141.Android.C/libHttpClient.141.Android.C.vcxproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
-    <UseOfStl>c++_static</UseOfStl>
+    <UseOfStl>c++_shared</UseOfStl>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">

--- a/Build/libHttpClient.141.Android.Java/libHttpClient.141.Android.Java.androidproj
+++ b/Build/libHttpClient.141.Android.Java/libHttpClient.141.Android.Java.androidproj
@@ -24,7 +24,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ProjectVersion>1.0</ProjectVersion>
     <ProjectGuid>{eef4b78b-7d2b-4a54-9944-5953d7df5b51}</ProjectGuid>
-    <AndroidAPILevel>android-23</AndroidAPILevel>
+    <AndroidAPILevel>android-19</AndroidAPILevel>
     <TargetExt>.aar</TargetExt>
     <_PackagingProjectWithoutNativeComponent>true</_PackagingProjectWithoutNativeComponent>
     <LaunchActivity Condition="'$(LaunchActivity)' == ''">com.libHttpClient.libHttpClient</LaunchActivity>


### PR DESCRIPTION
* Support deploying to android 19:

Set AndroidAPILevel to 19 for C++ project
Set MinSdk to 19 for java project
Set CompileSdk to 23 for java project (matching the target sdk)
Fixed str_icmp only working on windows

* Correct the compile version of android

* Use c++_shared